### PR TITLE
Fix "flush of closed file" crash in the caption overlay

### DIFF
--- a/src/sofit/render.py
+++ b/src/sofit/render.py
@@ -747,9 +747,18 @@ def _overlay_pillow_frames(video_path: Path, output_path: Path, width: int,
     ]
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-    for frame_idx in range(total_frames):
-        proc.stdin.write(make_frame(frame_idx / fps))
-    proc.stdin.close()
+    # `total_frames` comes from the CONTAINER duration, which an audio stream
+    # can extend past the video. ffmpeg then finishes on `-shortest` and closes
+    # the pipe while we are still writing, so a short write here is a normal
+    # finish, not an error. stdin is detached afterwards because communicate()
+    # would otherwise re-flush the closed pipe and mask ffmpeg's own stderr.
+    try:
+        for frame_idx in range(total_frames):
+            proc.stdin.write(make_frame(frame_idx / fps))
+        proc.stdin.close()
+    except (BrokenPipeError, ValueError):
+        pass
+    proc.stdin = None
     _, stderr = proc.communicate(timeout=FFMPEG_TIMEOUT)
     if proc.returncode != 0:
         raise RuntimeError(f"Caption overlay failed: {stderr.decode()[-500:]}")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -602,3 +602,36 @@ def test_audiogram_cmd_music_bed():
         music="/nonexistent/theme.mp3")
     fc = cmd[cmd.index("-filter_complex") + 1]
     assert "sidechaincompress" not in fc         # missing file: no bed
+
+
+# --- overlay pipe: ffmpeg finishing early must not raise -----------------
+
+def test_overlay_pillow_frames_survives_early_pipe_close(monkeypatch):
+    """`total_frames` is derived from the CONTAINER duration, which a longer
+    audio stream can push past the video. ffmpeg then exits on `-shortest` and
+    closes stdin mid-write; that is a normal finish, not a failure."""
+    from sofit import render
+
+    class _ClosedStdin:
+        def write(self, _b):
+            raise ValueError("flush of closed file")
+
+        def close(self):
+            raise ValueError("flush of closed file")
+
+    class _Proc:
+        returncode = 0
+
+        def __init__(self):
+            self.stdin = _ClosedStdin()
+
+        def communicate(self, timeout=None):
+            assert self.stdin is None, "stdin must be detached before communicate()"
+            return b"", b""
+
+    monkeypatch.setattr(render, "_probe_fps_frames", lambda p: (30.0, 300))
+    monkeypatch.setattr(render.subprocess, "Popen", lambda *a, **k: _Proc())
+
+    out = Path("out.mp4")
+    assert render._overlay_pillow_frames(
+        Path("in.mp4"), out, 16, 16, lambda t: b"\x00" * (16 * 16 * 4)) == out


### PR DESCRIPTION
Every caption burn-in through `_overlay_pillow_frames` ends in `ValueError: flush of closed file`, **after the render has already succeeded**.

### Cause

The function closes ffmpeg’s stdin after the last frame, then calls `communicate()`. CPython’s `Popen._communicate` flushes `self.stdin` first and guards only `BrokenPipeError`:

```python
try:
    self.stdin.flush()
except BrokenPipeError:
    pass  # communicate() must ignore BrokenPipeError
```

A file *we* closed raises `ValueError`, not `BrokenPipeError` — so the flush always raises. It also masks genuine ffmpeg failures, since the exception fires before `returncode` is ever checked; the traceback points into `subprocess` internals rather than at ffmpeg.

### Fix

Detach `stdin` once closed so `communicate()` has nothing to flush, and tolerate a short write for the case where ffmpeg exits first (`-shortest`, when the video is shorter than the container duration the frame count came from).

### Testing

- Adds a regression test that fails without the fix (verified by reverting).
- **Repairs `test_corrected_latin_token_burns_into_caption`, which currently fails on `main` at 7f9d014.** The suite goes from 112 passed / 1 failed to **113 passed**.

Found while rendering a hand-written clip spec via `--render-from`, which this made unusable.