### PR TITLE
Don't reorder caption lines that contain no RTL text

### DIFF
--- a/src/sofit/render.py
+++ b/src/sofit/render.py
@@ -624,6 +624,14 @@ def _bidi_word_order(words: list[dict]) -> list[dict]:
     they don't come out reversed. Hebrew-only lines are simply reversed, as
     before. Internal glyph shaping of each word is still Pillow/libraqm's job.
     """
+    # Base direction is RTL only when the line actually contains RTL letters.
+    # An all-Latin line can still hold neutral-only tokens ("&", "-", "|"),
+    # which are not _is_ltr_word, so they would form their own run and flip the
+    # line: "Under the Guides & Onboarding" -> "Onboarding & Under the Guides".
+    if not any("\u0590" <= c <= "\u05ff" or "\u0600" <= c <= "\u06ff"
+               for w in words for c in (w.get("text") or "")):
+        return list(words)
+
     runs: list[list] = []  # [is_ltr, [words]]
     for w in words:
         ltr = _is_ltr_word(w)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -602,3 +602,18 @@ def test_audiogram_cmd_music_bed():
         music="/nonexistent/theme.mp3")
     fc = cmd[cmd.index("-filter_complex") + 1]
     assert "sidechaincompress" not in fc         # missing file: no bed
+
+
+def test_bidi_leaves_ltr_only_lines_untouched():
+    """A line with no RTL letters is not a base-RTL line and must not be
+    reordered. Neutral-only tokens ("&", "-", "|") are not _is_ltr_word, so
+    before this they formed their own run and flipped the whole line."""
+    def order(line):
+        return [w["text"] for w in _bidi_word_order(_t(*line.split()))]
+
+    assert order("Under the Guides & Onboarding") == \
+        ["Under", "the", "Guides", "&", "Onboarding"]
+    assert order("A | B - C") == ["A", "|", "B", "-", "C"]
+    # RTL lines keep their existing visual reordering
+    assert order("שלום עולם") == ["עולם", "שלום"]
+    assert order("שלום OpenAI עולם") == ["עולם", "OpenAI", "שלום"]


### PR DESCRIPTION
English-only caption lines can render with their words reversed:

```
"Under the Guides & Onboarding"  ->  "Onboarding & Under the Guides"
```

### Cause

`_bidi_word_order` assumes a base-RTL paragraph and reverses the run order to produce visual left-to-right. Latin words stay upright because consecutive LTR words are grouped into a run — but the grouping key is `_is_ltr_word`, which requires an ASCII alphanumeric character. A neutral-only token (`&`, `-`, `|`) fails that test, so it forms its own “RTL” run, and the line goes through the reversal.

Reproducer on `main`:

```python
>>> from sofit.render import _bidi_word_order
>>> [w["text"] for w in _bidi_word_order([{"text": t} for t in "Under the Guides & Onboarding".split()])]
["Onboarding", "&", "Under", "the", "Guides"]
```

Any all-Latin line with such a token is affected — it does not need Hebrew to be present.

### Fix

A line with no RTL letters has no RTL base direction to honour, so return it unchanged. Lines containing Hebrew or Arabic keep the existing behaviour, including the mixed Hebrew/Latin brand-name case (`שלום OpenAI עולם` → `עולם OpenAI שלום`), which the added test pins.

### Note

One unrelated test, `test_corrected_latin_token_burns_into_caption`, fails on this branch — it already fails on `main` and is fixed by #3.