### PR TITLE
Make caption chunk thresholds configurable

### DIFF
--- a/src/sofit/render.py
+++ b/src/sofit/render.py
@@ -688,8 +688,12 @@ def _caption_entries(transcript: dict, start_time: float, end_time: float) -> li
     entries: list[dict] = []
     chunk: list[dict] = []
     punct = (".", "!", "?", ",", ";", ":", "…")
-    max_words = 6      # short chunks read better in short-form
-    max_span = 2.6
+    # Defaults are tuned for speech: short chunks read better in short-form.
+    # A spec written by hand (static labels over non-speech footage) needs a
+    # caption to stay up for its whole span, which these thresholds would
+    # otherwise split into one chunk per word.
+    max_words = int(os.environ.get("SOFIT_MAX_WORDS", "6"))
+    max_span = float(os.environ.get("SOFIT_MAX_SPAN", "2.6"))
 
     def flush() -> None:
         if not chunk:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -602,3 +602,20 @@ def test_audiogram_cmd_music_bed():
         music="/nonexistent/theme.mp3")
     fc = cmd[cmd.index("-filter_complex") + 1]
     assert "sidechaincompress" not in fc         # missing file: no bed
+
+
+def test_caption_chunking_thresholds_are_configurable(monkeypatch):
+    """A hand-written spec holds one caption for a whole span; the speech-tuned
+    2.6s cap would split that into one chunk per word."""
+    words = [{"t": 0.0, "d": 12.0, "w": w}
+             for w in "Under the Guides & Onboarding".split()]
+    tr = _clip_transcript({"start": 0.0, "end": 12.0, "words": words})
+
+    assert len(_caption_entries(tr, 0.0, 12.0)) == 5      # default: one per word
+
+    monkeypatch.setenv("SOFIT_MAX_SPAN", "9999")
+    monkeypatch.setenv("SOFIT_MAX_WORDS", "99")
+    entries = _caption_entries(tr, 0.0, 12.0)
+    assert len(entries) == 1
+    assert [w["text"] for w in entries[0]["words"]] == \
+        ["Under", "the", "Guides", "&", "Onboarding"]


### PR DESCRIPTION
Captions built from a hand-written clip spec display **one word at a time**.

### Cause

`_caption_entries` groups words with thresholds tuned for transcribed speech:

```python
max_words = 6
max_span = 2.6
```

A transcript-driven caption tracks the words being spoken, so a chunk naturally stays under 2.6s. A hand-written spec uses captions differently — a static label meant to stay up for its whole span. Such an entry exceeds `max_span` on its *very first word*, so `flush()` fires per word and only one word is ever on screen.

### Fix

Read both thresholds from the environment, defaults unchanged:

```bash
SOFIT_MAX_WORDS=99 SOFIT_MAX_SPAN=9999 sofit --render-from guide.json --render-clips out
```

Transcript-driven clips are untouched; this only gives a non-speech render a way to hold a full line.

### Alternative considered

The thresholds could instead be inferred (e.g. skip chunking when every word in a segment shares one window). That is less explicit and would change behaviour for existing specs, so env vars seemed the safer contract — happy to switch if you prefer.

### Note

`test_corrected_latin_token_burns_into_caption` fails on this branch; it already fails on `main` and is fixed by #3.