### PR TITLE
Add SOFIT_CAPTION_* knobs for caption weight

### DIFF
--- a/src/sofit/render.py
+++ b/src/sofit/render.py
@@ -654,8 +654,9 @@ def _load_caption_font(size: int, font: str | None = None):
             f = ImageFont.truetype(path, size)
         except Exception:
             continue
-        try:  # Rubik is a variable font — go as heavy as possible for social
-            f.set_variation_by_name("Black")
+        try:  # Rubik is a variable font — Black is the default social weight
+            f.set_variation_by_name(
+                os.environ.get("SOFIT_CAPTION_WEIGHT", "Black"))
         except Exception:
             pass
         return f
@@ -844,9 +845,13 @@ def _burn_captions_pillow(video_path: Path, entries: list[dict], output_path: Pa
                 w["start"] /= speed
                 w["end"] /= speed
 
-    font_size = max(28, height // 22)
+    # Caption weight. The defaults are a punchy social look; a calmer deck
+    # (screencast, HOWTO) can dial them down without a code change.
+    size_div = int(os.environ.get("SOFIT_CAPTION_DIV", "22"))
+    outline_px = os.environ.get("SOFIT_CAPTION_OUTLINE")
+    font_size = max(28, height // size_div)
     pil_font = _load_caption_font(font_size, font)
-    outline = max(3, font_size // 8)
+    outline = int(outline_px) if outline_px else max(3, font_size // 8)
     line_h = int(font_size * 1.28)
     w_frac, b_frac, _ = _SAFE_AREAS.get(safe_area, _SAFE_AREAS["none"])
     bottom_margin = int(height * b_frac)  # sit in the lower third, clear of the edge
@@ -926,7 +931,12 @@ def _burn_captions_pillow(video_path: Path, entries: list[dict], output_path: Pa
     def cta_w(txt: str) -> float:
         return measure.textlength(txt, font=cta_font)
 
-    active_color = accent or _ACCENT
+    # Static captions over non-speech footage have no spoken word to track,
+    # so the karaoke highlight is just noise: SOFIT_CAPTION_ACCENT=none drops it.
+    if os.environ.get("SOFIT_CAPTION_ACCENT", "").lower() == "none":
+        active_color = _WHITE
+    else:
+        active_color = accent or _ACCENT
     empty = Image.new("RGBA", (width, height), (0, 0, 0, 0)).tobytes("raw", "RGBA")
 
     def make_frame(t: float) -> bytes:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,6 +5,7 @@ Covers the two things most likely to break silently:
   * clip-relative word timings convert to correct SRT times
 """
 
+import os
 import pytest
 from pathlib import Path
 
@@ -602,3 +603,21 @@ def test_audiogram_cmd_music_bed():
         music="/nonexistent/theme.mp3")
     fc = cmd[cmd.index("-filter_complex") + 1]
     assert "sidechaincompress" not in fc         # missing file: no bed
+
+
+def test_caption_style_env_knobs(monkeypatch):
+    """SOFIT_CAPTION_* tune caption weight; unset means the social defaults."""
+    from sofit.render import _load_caption_font
+
+    # Font weight: the knob reaches the variable-font axis.
+    base = _load_caption_font(48)
+    monkeypatch.setenv("SOFIT_CAPTION_WEIGHT", "Regular")
+    light = _load_caption_font(48)
+    if hasattr(base, "get_variation_names"):        # bundled Rubik present
+        assert base.font.style != light.font.style
+
+    # Size divisor and outline are read at burn time from the environment.
+    monkeypatch.setenv("SOFIT_CAPTION_DIV", "44")
+    assert max(28, 1080 // int(os.environ["SOFIT_CAPTION_DIV"])) == 28
+    monkeypatch.delenv("SOFIT_CAPTION_DIV")
+    assert max(28, 1080 // int(os.environ.get("SOFIT_CAPTION_DIV", "22"))) == 49


### PR DESCRIPTION
The caption style is fixed: Rubik **Black**, outline `font_size // 8`, and a yellow karaoke highlight on the active word.

That is the right look for a social clip. On a dense screencast it is overpowering — the text competes with the UI it is describing — and the highlight is meaningless when nothing is spoken, because a static caption has no “current word” to track.

### Change

Four optional env vars, all defaulting to current behaviour:

| Variable | Default | Effect |
|---|---|---|
| `SOFIT_CAPTION_DIV` | `22` | `font_size = height // DIV`; higher = smaller |
| `SOFIT_CAPTION_WEIGHT` | `Black` | Rubik variation name (`Light`…`Black`) |
| `SOFIT_CAPTION_OUTLINE` | `font_size // 8` | outline thickness in px |
| `SOFIT_CAPTION_ACCENT` | — | `none` disables the highlight |

```bash
SOFIT_CAPTION_DIV=32 SOFIT_CAPTION_WEIGHT=SemiBold \
SOFIT_CAPTION_OUTLINE=2 SOFIT_CAPTION_ACCENT=none \
sofit --render-from guide.json --render-clips out --aspect 16:9
```

### Notes

This is the most opinionated of the four PRs and the easiest to drop — env vars may not be the contract you want for styling. A `--caption-style {social,plain}` flag, or fields on the clip spec, would both be reasonable alternatives; happy to rework.

`test_corrected_latin_token_burns_into_caption` fails on this branch; it already fails on `main` and is fixed by #3.