### PR TITLE
ci: scope pytest to tests/ and sync __version__ to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sofit"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/sofit/__init__.py
+++ b/src/sofit/__init__.py
@@ -4,4 +4,4 @@ Pipeline: media file -> local faster-whisper transcript (cached) -> Claude
 generates chapters / show notes / quotes -> formatted output.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.6.0"


### PR DESCRIPTION
## What

- `pyproject.toml`: add `[tool.pytest.ini_options]` with `testpaths = ["tests"]`
- `src/sofit/__init__.py`: `__version__` `0.4.1` → `0.6.0`

## Why

**testpaths** — bare `pytest -q` (what `ci.yml` runs) collected from the repo root, which imports `scripts/publish/test_rank.py`. That file is a module-level assert script, not a pytest module: it has no `test_*` functions, and its checks, `print`s and `sys.path.insert` all execute as an *import side effect* during collection. Scoping to `tests/` stops that. Verified load-bearing: with `-o testpaths=` the side-effect output reappears, with the config it does not.

**Version** — `cli.py` exposes `__version__` via `--version`, so `sofit --version` was reporting a stale `0.4.1` against a `0.6.0` package.

## Note on the CI premise

This was filed as "CI on main is failing," but **main is currently green** (run [32749648347](https://github.com/navotvolkgroundup/sofit/actions/runs/32749648347) on `08aa08a`). The `SystemExit` on a missing `~/.sofit/publish.json` was already fixed in `8240efe`, which made `_publish_cfg()` import-safe; the last red run after that was the PIL issue fixed in `08aa08a`. Neither change here fixes an active failure - the version sync is a real user-visible bug, and `testpaths` is hardening against that class of collection breakage recurring.

## Test

`pytest -q` from the repo root: **129 passed**. Also green with `HOME` pointed at an empty dir (simulating CI having no `~/.sofit/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
