### PR TITLE
ci: run push trigger only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
@@ -13,3 +14,4 @@ jobs:
           python-version: "3.12"
       - run: pip install -e ".[dev,mcp]"
       - run: pytest -q
+


### PR DESCRIPTION
`on: push` with no branch filter fired on every push to any branch, so PR branches double-ran (push + pull_request events for the same code). Limiting push to main keeps PR coverage identical and halves the runs on branch work.

Context: account Actions quota pressure (90% of monthly minutes used one day after reset).