### PR TITLE
ci: cancel superseded runs with concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  # One active run per ref: pushing to a branch cancels its stale run
+  # instead of letting superseded runs burn minutes to completion.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,4 +20,3 @@ jobs:
           python-version: "3.12"
       - run: pip install -e ".[dev,mcp]"
       - run: pytest -q
-


### PR DESCRIPTION
Adds a workflow-level concurrency group (`ci-${{ github.ref }}`) with `cancel-in-progress: true`, so pushing to a branch cancels its stale CI run instead of letting superseded runs burn Actions minutes to completion.

No behavior change for the latest run on any ref; tests, triggers, and steps are unchanged.